### PR TITLE
Use VONAGE_BRAND_NAME

### DIFF
--- a/sms/send-unicode-sms.rb
+++ b/sms/send-unicode-sms.rb
@@ -3,6 +3,7 @@ require 'vonage'
 
 VONAGE_API_KEY = ENV['VONAGE_API_KEY']
 VONAGE_API_SECRET = ENV['VONAGE_API_SECRET']
+VONAGE_BRAND_NAME = ENV['VONAGE_BRAND_NAME']
 TO_NUMBER = ENV['TO_NUMBER']
 
 client = Vonage::Client.new(
@@ -11,7 +12,7 @@ client = Vonage::Client.new(
 )
 
 client.sms.send(
-  from: 'Acme Inc',
+  from: VONAGE_BRAND_NAME,
   to: TO_NUMBER,
   text: 'こんにちは世界',
   type: "unicode"

--- a/sms/send.rb
+++ b/sms/send.rb
@@ -3,6 +3,7 @@ require 'vonage'
 
 VONAGE_API_KEY = ENV['VONAGE_API_KEY']
 VONAGE_API_SECRET = ENV['VONAGE_API_SECRET']
+VONAGE_BRAND_NAME = ENV['VONAGE_BRAND_NAME']
 TO_NUMBER = ENV['TO_NUMBER']
 
 client = Vonage::Client.new(
@@ -11,7 +12,7 @@ client = Vonage::Client.new(
 )
 
 client.sms.send(
-  from: 'Acme Inc',
+  from: VONAGE_BRAND_NAME,
   to: TO_NUMBER,
   text: 'A text message sent using the Vonage SMS API'
 )


### PR DESCRIPTION
The SMS code snippets reference the `VONAGE_BRAND_NAME` but the Ruby snippets were not using it. This fixes [the issue](https://github.com/Nexmo/nexmo-developer/issues/2834)