### PR TITLE
fix typo

### DIFF
--- a/voice/retrieve-info-for-all-calls.rb
+++ b/voice/retrieve-info-for-all-calls.rb
@@ -15,7 +15,7 @@ yesterday = now - (3600 * 24)
 
 response = client.voice.list({date_start: yesterday.utc.iso8601, date_end: now.utc.iso8601})
 
-calls = response._embedded.voice
+calls = response._embedded.calls
 calls.each do |call|
   puts call.inspect
 end


### PR DESCRIPTION
I got this message.

> vonage-7.8.2/lib/vonage/entity.rb:24:in `method_missing': undefined method `voice'

